### PR TITLE
Fix invalid chars

### DIFF
--- a/docs/source/rules_schema.rst
+++ b/docs/source/rules_schema.rst
@@ -23,8 +23,8 @@ A typical rules file looks like this:
             - Bob
 
     sidecar : 
-        EEGReference : 50
-        PowerLineFrequency : FCz
+        EEGReference : FCz
+        PowerLineFrequency : 50
 
     channels : 
         name :
@@ -185,8 +185,8 @@ The sidecar object ends up looking something like the following:
 .. code-block:: yaml
 
     sidecar : 
-        EEGReference : 50
-        PowerLineFrequency : FCz
+        EEGReference : FCz
+        PowerLineFrequency : 50
 
 
 channels

--- a/docs/source/rules_schema.rst
+++ b/docs/source/rules_schema.rst
@@ -338,6 +338,7 @@ You associate each of the properties you want to extract to the properties of th
 
 These have to be written in a property called *fields* and in the order as they appear in the regex pattern (from left to right).
 
+
 .. note::
 
     Notice sovabids uses dot notation to nest properties. That is ```field1.field2`` means that we get inside ``field1`` and then inside ``field2``.
@@ -372,6 +373,9 @@ So your *path_analysis* object is wrote in the *Rules File* as:
     Use the forward-slash as the path separator (``/``) in your path strings regardless of the symbol your OS uses. This is to avoid problems when reading strings. This applies to all of the modes of *path_analysis* :
     regex patterns, placeholder patterns and paired example.
 
+.. warning::
+    If the value extracted from a field includes hyphens or underscores (-,_) they will be deleted from the value so as to accomodate automatically to the bids standard.
+    The only way to bypass this is if the field is "ignore" (without the quotations).
 
 placeholder pattern
 """""""""""""""""""
@@ -426,6 +430,10 @@ Now you just need to set the pattern, remember we need to use forward-slash nota
 .. tip::
 
     You can use %ignore% if that part of the pattern varies but you don't care about its value.
+
+.. warning::
+    If the value extracted from a field includes hyphens or underscores (-,_) they will be deleted from the value so as to accomodate automatically to the bids standard.
+    The only way to bypass this is if the field is "ignore".
 
 The placeholder has two advanced configurations which define how the pattern is translated to a regex pattern:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,6 @@ flask
 uvicorn
 fastapi-jsonrpc
 versioneer
-git+https://github.com/yjmantilla/mne-bids.git@neuroscan
+https://api.github.com/repos/mne-tools/mne-bids/zipball/main
 git+https://github.com/yjmantilla/bidscoin.git@sovabids
 -e .

--- a/requirements-user.txt
+++ b/requirements-user.txt
@@ -1,3 +1,3 @@
 bids_validator
-git+https://github.com/yjmantilla/mne-bids.git@neuroscan
+https://api.github.com/repos/mne-tools/mne-bids/zipball/main
 .

--- a/requirements-user.txt
+++ b/requirements-user.txt
@@ -1,2 +1,3 @@
+bids_validator
 git+https://github.com/yjmantilla/mne-bids.git@neuroscan
 .

--- a/sovabids/convert.py
+++ b/sovabids/convert.py
@@ -52,9 +52,13 @@ def convert_them(mappings_input):
     num_files = len(mappings['Individual'])
     for i,mapping in enumerate(mappings['Individual']):
         input_file=deep_get(mapping,'IO.source',None)
-        LOGGER.info(f"File {i+1} of {num_files} ({(i+1)*100/num_files}%) : {input_file}")
+        try:
 
-        apply_rules_to_single_file(input_file,mapping,bids_path,write=True)
+            LOGGER.info(f"File {i+1} of {num_files} ({(i+1)*100/num_files}%) : {input_file}")
+
+            apply_rules_to_single_file(input_file,mapping,bids_path,write=True)
+        except:
+            LOGGER.info('Error for '+ input_file)
 
     LOGGER.info(f"Conversion Done!")
 

--- a/sovabids/convert.py
+++ b/sovabids/convert.py
@@ -57,8 +57,8 @@ def convert_them(mappings_input):
             LOGGER.info(f"File {i+1} of {num_files} ({(i+1)*100/num_files}%) : {input_file}")
 
             apply_rules_to_single_file(input_file,mapping,bids_path,write=True)
-        except:
-            LOGGER.info('Error for '+ input_file)
+        except TheError:
+            LOGGER.exception(f'Error for {input_file}')
 
     LOGGER.info(f"Conversion Done!")
 

--- a/sovabids/datasets.py
+++ b/sovabids/datasets.py
@@ -50,8 +50,9 @@ def lemon_prepare():
     tars = [x for x in filepaths if 'tar.gz' in x ]
 
     # SUBJECTS
-    old_ids = [parse_from_regex(x,'(sub-.*?).tar.gz',['id']) for x in tars]
-    old_ids = [x['id'] for x in old_ids]
+    # ignore field so that it doesnt get rid of - or _
+    old_ids = [parse_from_regex(x,'(sub-.*?).tar.gz',['ignore']) for x in tars]
+    old_ids = [x['ignore'] for x in old_ids]
     new_ids = [name_match.loc[(name_match.INDI_ID==x),'Initial_ID']._values[0] for x in old_ids]
 
     # EEG FILES

--- a/sovabids/parsers.py
+++ b/sovabids/parsers.py
@@ -99,7 +99,7 @@ def parse_from_regex(string,pattern,fields):
     l = []
     
     for field,value in zip(fields,list(match.groups())):
-        if '_' in value or '-' in value:
+        if field != 'ignore' and ('_' in value or '-' in value):
             value2 = value.replace('_','')
             value2 = value2.replace('-','')
             d = nested_notation_to_tree(field,value2)

--- a/sovabids/parsers.py
+++ b/sovabids/parsers.py
@@ -99,7 +99,12 @@ def parse_from_regex(string,pattern,fields):
     l = []
     
     for field,value in zip(fields,list(match.groups())):
-        d = nested_notation_to_tree(field,value)
+        if '_' in value or '-' in value:
+            value2 = value.replace('_','')
+            value2 = value2.replace('-','')
+            d = nested_notation_to_tree(field,value2)
+        else:
+            d = nested_notation_to_tree(field,value)        
         l.append(d)
     return deep_merge_N(l)
 

--- a/sovabids/parsers.py
+++ b/sovabids/parsers.py
@@ -41,6 +41,9 @@ def placeholder_to_regex(placeholder,encloser='%',matcher='(.+)'):
 def parse_from_placeholder(string,pattern,encloser='%',matcher='(.+)'):
     """Parse string from a placeholder pattern.
 
+    Danger: It will replace underscores and hyphens with an empty character in all fields
+    except for the ignore field. This to accomodate to the bids standard restrictions automatically.
+
     Parameters
     ----------
 
@@ -65,6 +68,9 @@ def parse_from_placeholder(string,pattern,encloser='%',matcher='(.+)'):
 def parse_from_regex(string,pattern,fields):
     """Parse string from regex pattern.
 
+    Danger: It will replace underscores and hyphens with an empty character in all fields
+    except for the ignore field. This to accomodate to the bids standard restrictions automatically.
+    
     Parameters
     ----------
     string : str

--- a/sovabids/rules.py
+++ b/sovabids/rules.py
@@ -459,8 +459,8 @@ def apply_rules(source_path,bids_path,rules,mapping_path=''):
             LOGGER.info(f"File {i+1} of {num_files} ({(i+1)*100/num_files}%) : {f}")
             map,_ = apply_rules_to_single_file(f,rules_copy,bids_path,write=False,preview=False) #TODO There should be a way to control how verbose this is
             all_mappings.append(map)
-        except:
-            LOGGER.info('Error for '+f)
+        except TheError:
+            LOGGER.exception(f'Error for {f}')
             
             
 

--- a/sovabids/rules.py
+++ b/sovabids/rules.py
@@ -455,9 +455,14 @@ def apply_rules(source_path,bids_path,rules,mapping_path=''):
     all_mappings = []
     num_files = len(filepaths)
     for i,f in enumerate(filepaths):
-        LOGGER.info(f"File {i+1} of {num_files} ({(i+1)*100/num_files}%) : {f}")
-        map,_ = apply_rules_to_single_file(f,rules_copy,bids_path,write=False,preview=False) #TODO There should be a way to control how verbose this is
-        all_mappings.append(map)
+        try:
+            LOGGER.info(f"File {i+1} of {num_files} ({(i+1)*100/num_files}%) : {f}")
+            map,_ = apply_rules_to_single_file(f,rules_copy,bids_path,write=False,preview=False) #TODO There should be a way to control how verbose this is
+            all_mappings.append(map)
+        except:
+            LOGGER.info('Error for '+f)
+            
+            
 
 
     LOGGER.info(f"Individual Mappings Done!")

--- a/tests/test_path_parser.py
+++ b/tests/test_path_parser.py
@@ -58,7 +58,8 @@ def test_parse_from_regex():
     path_pattern = '(.*?).vhdr'
     fields = 'entities.subject'
     result = parse_from_regex(string,path_pattern,fields)
-    assert result['entities']['subject'] == 'y:/code/sovabids/_data/lemon/sub-010002'
+    assert result['entities']['subject'] == 'y:/code/sovabids/data/lemon/sub010002'
+    # Notice replacement of '_' to '', expected as bids does not accept _,-
 
     path_pattern = 'sub-(.*)' # notice no "?",or use .+
     fields = 'entities.subject'
@@ -95,7 +96,8 @@ def test_parse_from_placeholder():
 
     path_pattern = '%entities.subject%.vhdr'
     result = parse_from_placeholder(string,path_pattern,matcher=matcher)
-    assert result['entities']['subject'] == 'y:/code/sovabids/_data/lemon/sub-010002'
+    assert result['entities']['subject'] == 'y:/code/sovabids/data/lemon/sub010002'
+    # Notice replacement of '_' to '', expected as bids does not accept _,-
 
     path_pattern = 'sub-%entities.subject%'
     result = parse_from_placeholder(string,path_pattern,matcher=matcher)


### PR DESCRIPTION
- CNT implementation. Closes #48 , but by requiring the latest dev version of mne-bids. Once they include it on the stable version we should ask for the stable one.
- Fixes bids_validator requirement missing in the user installation mode. This is used in heuristics.py.
- Now if an entity value has ``'_'`` or ``'-'``, they will be changed to ``''`` automatically to adapt to the bids standard. In the future it would be nice for the user to choose which replacement to do.
- Now, files with problems for conversion or rules applying will be skipped and the corresponding error and filepath will be saved on the log. 
- Typo correction. Closes #53 