### PR TITLE
Update parsers.py

### DIFF
--- a/sovabids/parsers.py
+++ b/sovabids/parsers.py
@@ -2,7 +2,6 @@
 import re
 from copy import deepcopy
 
-from numpy import mat
 from sovabids.misc import flat_paren_counter
 from sovabids.dicts import deep_merge_N,nested_notation_to_tree
 


### PR DESCRIPTION
Removed "from numpy import mat" as was throwing an error (probably due to a numpy version upgrade). I believe that 'mat' is not used, so all good.