### PR TITLE
Update sovarpc.py

### DIFF
--- a/sovabids/sovarpc.py
+++ b/sovabids/sovarpc.py
@@ -284,7 +284,7 @@ app.bind_entrypoint(api)
 
 def main(entry='sovarpc:app',port=5000,debug=False):
     import uvicorn
-    uvicorn.run(entry, port=port, debug=debug, access_log=False)
+    uvicorn.run(entry, port=port, access_log=False)
 
 if __name__ == '__main__':
     main(port=5100)


### PR DESCRIPTION
uvicorn.run does not accept debug argument anymore (it throws an error if used). Probably due to upgrade of the uvicorn package.
So I had to remove the debug argument for now.
