### PR TITLE
Output log information to stdout

### DIFF
--- a/sovabids/convert.py
+++ b/sovabids/convert.py
@@ -80,12 +80,20 @@ def convert_them(mappings_input):
 def sovaconvert():
     """Console script usage for conversion."""
     # see https://github.com/Donders-Institute/bidscoin/blob/master/bidscoin/bidsmapper.py for example of how to make this
+    logging.basicConfig(format="%(message)s")
+    LOGGER.setLevel(logging.WARN)
+
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers()
 
     parser = subparsers.add_parser('convert_them')
     parser.add_argument('mappings',help='The mapping file of the conversion.')
+    parser.add_argument('-v','--verbose', action="store_true", help='Make the output more verbose.')
     args = parser.parse_args()
+
+    if args.verbose:
+        LOGGER.setLevel(logging.INFO)
+
     convert_them(args.mappings)
 
 if __name__ == "__main__":

--- a/sovabids/rules.py
+++ b/sovabids/rules.py
@@ -25,7 +25,6 @@ from sovabids.loggers import setup_logging
 from sovabids.settings import SECTION_STRING
 from sovabids.heuristics import from_io_example
 
-import logging
 LOGGER = logging.getLogger(__name__)
 
 def _regex_match(pattern,string):
@@ -534,12 +533,20 @@ def sovapply():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers()
 
+    logging.basicConfig(format="%(message)s")
+    LOGGER.setLevel(logging.WARN)
+
     parser = subparsers.add_parser('apply_rules')
     parser.add_argument('source_path',help='The path to the input data directory that will be converted to bids')  # add the name argument
     parser.add_argument('bids_path',help='The path to the output bids directory')  # add the name argument
     parser.add_argument('rules',help='The fullpath of the rules file')  # add the name argument
     parser.add_argument('-m','--mapping', help='The fullpath of the mapping file to be written. If not set it will be located in bids_path/code/sovabids/mappings.yml',default='')
+    parser.add_argument('-v','--verbose', action="store_true", help='Make the output more verbose.')
     args = parser.parse_args()
+
+    if args.verbose:
+        LOGGER.setLevel(logging.INFO)
+        
     apply_rules(args.source_path,args.bids_path,args.rules,args.mapping)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Log messages were not showing up in the terminal when running `sovapply` or `sovaconvert`. This PR fixes that and adds an additional `-v` / `--verbose` flag to control the log level (by default it's WARN and with the verbose flag turned on it becomes INFO)