### PR TITLE
TUI: validate power-line frequency; remove dead _mappings reactive

### DIFF
--- a/sovabids/tui.py
+++ b/sovabids/tui.py
@@ -708,6 +708,17 @@ class RulesPane(Static):
     def get_rules_file(self) -> str:
         return self.query_one("#rules-file-input", Input).value.strip()
 
+    def plf_error(self) -> str:
+        """Return an error message if the power-line frequency is set but not a
+        number, else "". Lets an action block instead of silently dropping it (#102)."""
+        val = self.query_one("#plf-input", Input).value.strip()
+        if val:
+            try:
+                float(val)
+            except ValueError:
+                return f"Power line frequency must be a number in Hz, got: {val}"
+        return ""
+
     def on_select_changed(self, event: Select.Changed) -> None:
         if event.select.id == "ext-select":
             self._schedule_ext_count()
@@ -1101,7 +1112,12 @@ class MappingsPane(Static):
                 self._set_status(f"Could not read rules file: {exc}", error=True)
                 return
         else:
-            rules = self.app.query_one(RulesPane).get_rules()
+            rules_pane = self.app.query_one(RulesPane)
+            plf_err = rules_pane.plf_error()
+            if plf_err:
+                self._set_status(plf_err, error=True)
+                return
+            rules = rules_pane.get_rules()
 
         self._set_status("Generating mappings…")
         self._gen_worker(source, bids, rules)
@@ -1283,6 +1299,10 @@ class SovabidsApp(App):
                 "A rules file is loaded — clear it in the Rules tab to save builder rules.",
                 severity="warning",
             )
+            return
+        plf_err = rules_pane.plf_error()
+        if plf_err:
+            self.notify(plf_err, severity="warning")
             return
         rules = rules_pane.get_rules()
         out = os.path.join(bids, "code", "sovabids", "rules.yml")

--- a/sovabids/tui.py
+++ b/sovabids/tui.py
@@ -11,8 +11,8 @@ import yaml
 from textual import work
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, ScrollableContainer, Vertical
-from textual.reactive import reactive
 from textual.screen import ModalScreen
+from textual.validation import ValidationResult, Validator
 from textual.widgets import (
     Button,
     DataTable,
@@ -481,6 +481,21 @@ def _flatten_dict(d: dict, prefix: str = "") -> dict:
     return out
 
 
+class _OptionalNumber(Validator):
+    """Blank is allowed (the field is optional); a non-blank value must parse as a
+    number. Used so an unparseable power-line frequency is flagged instead of
+    silently dropped."""
+
+    def validate(self, value: str) -> ValidationResult:
+        if not value.strip():
+            return self.success()
+        try:
+            float(value)
+        except ValueError:
+            return self.failure("Enter a number in Hz, e.g. 50")
+        return self.success()
+
+
 # ── Rules tab ─────────────────────────────────────────────────────────────────
 
 class RulesPane(Static):
@@ -663,7 +678,7 @@ class RulesPane(Static):
             yield Button("Power Spectrum", id="show-psd", variant="default", disabled=True)
             yield Button("Channel Names", id="show-channels", variant="default", disabled=True)
         yield Label("Power line frequency (Hz)")
-        yield Input(placeholder="50", id="plf-input")
+        yield Input(placeholder="50", id="plf-input", validators=[_OptionalNumber()])
         yield Label("EEG reference")
         yield Input(placeholder="FCz", id="ref-input")
 
@@ -1042,8 +1057,6 @@ class MappingsPane(Static):
     MappingsPane Horizontal { height: 3; margin-bottom: 1; }
     MappingsPane Button { margin-right: 1; }
     """
-
-    _mappings: reactive[list] = reactive([])
 
     def compose(self) -> ComposeResult:
         with Horizontal():

--- a/sovabids/tui.py
+++ b/sovabids/tui.py
@@ -481,19 +481,30 @@ def _flatten_dict(d: dict, prefix: str = "") -> dict:
     return out
 
 
+def _plf_problem(value: str) -> str:
+    """Return why ``value`` is not a usable power-line frequency, or "" if fine.
+    Blank is fine (optional); otherwise it must parse and be a positive, finite
+    number (rejects nan/inf/negative, which float() would otherwise accept)."""
+    import math
+
+    if not value.strip():
+        return ""
+    try:
+        num = float(value)
+    except ValueError:
+        return f"Power line frequency must be a number in Hz, got: {value}"
+    if not math.isfinite(num) or num <= 0:
+        return f"Power line frequency must be a positive number in Hz, got: {value}"
+    return ""
+
+
 class _OptionalNumber(Validator):
-    """Blank is allowed (the field is optional); a non-blank value must parse as a
-    number. Used so an unparseable power-line frequency is flagged instead of
-    silently dropped."""
+    """Blank is allowed (the field is optional); a non-blank value must be a positive,
+    finite number. Flags an unusable power-line frequency instead of dropping it."""
 
     def validate(self, value: str) -> ValidationResult:
-        if not value.strip():
-            return self.success()
-        try:
-            float(value)
-        except ValueError:
-            return self.failure("Enter a number in Hz, e.g. 50")
-        return self.success()
+        problem = _plf_problem(value)
+        return self.failure(problem) if problem else self.success()
 
 
 # ── Rules tab ─────────────────────────────────────────────────────────────────
@@ -709,15 +720,10 @@ class RulesPane(Static):
         return self.query_one("#rules-file-input", Input).value.strip()
 
     def plf_error(self) -> str:
-        """Return an error message if the power-line frequency is set but not a
-        number, else "". Lets an action block instead of silently dropping it (#102)."""
-        val = self.query_one("#plf-input", Input).value.strip()
-        if val:
-            try:
-                float(val)
-            except ValueError:
-                return f"Power line frequency must be a number in Hz, got: {val}"
-        return ""
+        """Return an error message if the power-line frequency is set but not a usable
+        (positive, finite) number, else "". Lets an action block instead of silently
+        dropping it (#102)."""
+        return _plf_problem(self.query_one("#plf-input", Input).value.strip())
 
     def on_select_changed(self, event: Select.Changed) -> None:
         if event.select.id == "ext-select":

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -570,6 +570,9 @@ async def test_tui_plf_field_validates_number(tmp_path):
         assert plf.validate("50").is_valid
         assert plf.validate("50.5").is_valid
         assert not plf.validate("50hz").is_valid   # flagged, not silently dropped
+        assert not plf.validate("nan").is_valid    # non-finite rejected
+        assert not plf.validate("inf").is_valid
+        assert not plf.validate("-5").is_valid     # must be positive
         from sovabids.tui import MappingsPane
         assert not hasattr(MappingsPane, "_mappings")
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -558,6 +558,23 @@ async def test_tui_rules_shows_sample_paths(dummy_source):
 
 
 @pytest.mark.anyio
+async def test_tui_plf_field_validates_number(tmp_path):
+    """A non-numeric power-line frequency is flagged (not silently dropped); blank and
+    numbers are accepted. Also guards that the dead `_mappings` reactive stays removed."""
+    app = SovabidsApp()
+    async with app.run_test(size=(120, 80)) as pilot:
+        app.query_one("TabbedContent").active = "tab-rules"
+        await pilot.pause()
+        plf = app.query_one("#plf-input", Input)
+        assert plf.validate("").is_valid          # blank ok (optional field)
+        assert plf.validate("50").is_valid
+        assert plf.validate("50.5").is_valid
+        assert not plf.validate("50hz").is_valid   # flagged, not silently dropped
+        from sovabids.tui import MappingsPane
+        assert not hasattr(MappingsPane, "_mappings")
+
+
+@pytest.mark.anyio
 async def test_tui_files_modal(dummy_source):
     app = SovabidsApp()
     # tall viewport so the Rules-tab content (ext + sample paths + pattern +

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -573,6 +573,17 @@ async def test_tui_plf_field_validates_number(tmp_path):
         from sovabids.tui import MappingsPane
         assert not hasattr(MappingsPane, "_mappings")
 
+        # and an invalid PLF must BLOCK Generate (not be silently dropped by get_rules)
+        app.query_one("#source-input", Input).value = "/some/source"
+        app.query_one("#bids-input", Input).value = "/some/bids"
+        plf.value = "50hz"
+        await pilot.pause()
+        app.query_one(MappingsPane)._generate()
+        await pilot.pause()
+        status = str(app.query_one("#mappings-status", Static).render()).lower()
+        assert "power line frequency" in status
+        assert getattr(app, "_mapping_data", None) is None   # no generation started
+
 
 @pytest.mark.anyio
 async def test_tui_files_modal(dummy_source):


### PR DESCRIPTION
Fixes #102.

Two small, independent TUI fixes:

**1. Invalid power-line frequency is no longer silently dropped.** `get_rules` did `float(plf)` in a bare `except ValueError: pass`, so a typo like `50hz` produced rules with no `PowerLineFrequency` and no feedback. The field now carries an optional-number validator (blank stays valid since the field is optional), so a non-numeric value is flagged in the UI.

**2. Removed the dead `MappingsPane._mappings` reactive.** It was declared `reactive([])` but never read or written — the mappings live on `app._mapping_data` — and being a shared-mutable default no watcher ever fired. Dropped it and its now-unused `reactive` import.

Added `test_tui_plf_field_validates_number` (blank/number accepted, `50hz` rejected; also guards the reactive stays removed). Full TUI suite green.

First of a stack of TUI/rules follow-up fixes (#98–#102, #94–#95).