### PR TITLE
TUI: fix preview-worker races and stale action buttons

### DIFF
--- a/sovabids/tui.py
+++ b/sovabids/tui.py
@@ -708,6 +708,17 @@ class RulesPane(Static):
     def get_rules_file(self) -> str:
         return self.query_one("#rules-file-input", Input).value.strip()
 
+    def plf_error(self) -> str:
+        """Return an error message if the power-line frequency is set but not a
+        number, else "". Lets an action block instead of silently dropping it (#102)."""
+        val = self.query_one("#plf-input", Input).value.strip()
+        if val:
+            try:
+                float(val)
+            except ValueError:
+                return f"Power line frequency must be a number in Hz, got: {val}"
+        return ""
+
     def on_select_changed(self, event: Select.Changed) -> None:
         if event.select.id == "ext-select":
             self._schedule_ext_count()
@@ -1101,7 +1112,12 @@ class MappingsPane(Static):
                 self._set_status(f"Could not read rules file: {exc}", error=True)
                 return
         else:
-            rules = self.app.query_one(RulesPane).get_rules()
+            rules_pane = self.app.query_one(RulesPane)
+            plf_err = rules_pane.plf_error()
+            if plf_err:
+                self._set_status(plf_err, error=True)
+                return
+            rules = rules_pane.get_rules()
 
         self._set_status("Generating mappings…")
         self._gen_worker(source, bids, rules)
@@ -1283,6 +1299,10 @@ class SovabidsApp(App):
                 "A rules file is loaded — clear it in the Rules tab to save builder rules.",
                 severity="warning",
             )
+            return
+        plf_err = rules_pane.plf_error()
+        if plf_err:
+            self.notify(plf_err, severity="warning")
             return
         rules = rules_pane.get_rules()
         out = os.path.join(bids, "code", "sovabids", "rules.yml")

--- a/sovabids/tui.py
+++ b/sovabids/tui.py
@@ -11,8 +11,8 @@ import yaml
 from textual import work
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, ScrollableContainer, Vertical
-from textual.reactive import reactive
 from textual.screen import ModalScreen
+from textual.validation import ValidationResult, Validator
 from textual.widgets import (
     Button,
     DataTable,
@@ -481,6 +481,21 @@ def _flatten_dict(d: dict, prefix: str = "") -> dict:
     return out
 
 
+class _OptionalNumber(Validator):
+    """Blank is allowed (the field is optional); a non-blank value must parse as a
+    number. Used so an unparseable power-line frequency is flagged instead of
+    silently dropped."""
+
+    def validate(self, value: str) -> ValidationResult:
+        if not value.strip():
+            return self.success()
+        try:
+            float(value)
+        except ValueError:
+            return self.failure("Enter a number in Hz, e.g. 50")
+        return self.success()
+
+
 # ── Rules tab ─────────────────────────────────────────────────────────────────
 
 class RulesPane(Static):
@@ -663,7 +678,7 @@ class RulesPane(Static):
             yield Button("Power Spectrum", id="show-psd", variant="default", disabled=True)
             yield Button("Channel Names", id="show-channels", variant="default", disabled=True)
         yield Label("Power line frequency (Hz)")
-        yield Input(placeholder="50", id="plf-input")
+        yield Input(placeholder="50", id="plf-input", validators=[_OptionalNumber()])
         yield Label("EEG reference")
         yield Input(placeholder="FCz", id="ref-input")
 
@@ -1042,8 +1057,6 @@ class MappingsPane(Static):
     MappingsPane Horizontal { height: 3; margin-bottom: 1; }
     MappingsPane Button { margin-right: 1; }
     """
-
-    _mappings: reactive[list] = reactive([])
 
     def compose(self) -> ComposeResult:
         with Horizontal():

--- a/sovabids/tui.py
+++ b/sovabids/tui.py
@@ -967,6 +967,11 @@ class RulesPane(Static):
         self.query_one("#show-psd", Button).disabled = self._psd_in_flight or not bool(self._matched_files)
 
     def _schedule_preview(self) -> None:
+        # Invalidate immediately on the edit (not only when the debounced scan fires):
+        # supersede any in-flight worker and clear the now-stale matches/buttons, then
+        # debounce merely *starting* the replacement scan (#99).
+        self._preview_gen += 1
+        self._update_show_files_btn([])
         if self._preview_timer is not None:
             self._preview_timer.stop()
         self._preview_timer = self.set_timer(0.6, self._run_preview)

--- a/sovabids/tui.py
+++ b/sovabids/tui.py
@@ -509,6 +509,7 @@ def _open_path_in_viewer(path: str) -> bool:
     browser with a *valid* ``file://`` URI (``as_uri`` handles Windows drives/spaces)."""
     import subprocess
     import sys
+    import threading
     import webbrowser
     from pathlib import Path
 
@@ -522,7 +523,15 @@ def _open_path_in_viewer(path: str) -> bool:
             if proc.wait(timeout=2) == 0:
                 return True                    # exited cleanly -> handed off
         except subprocess.TimeoutExpired:
-            return True                        # still running -> attached to the viewer; leave it
+            # still running -> attached to the viewer; leave it, but reap it when it
+            # eventually exits (a daemon wait) so it doesn't linger as a zombie
+            def _reap(p=proc):
+                try:
+                    p.wait()
+                except Exception:
+                    pass
+            threading.Thread(target=_reap, daemon=True).start()
+            return True
     except Exception:
         pass
     # opener missing or exited non-zero -> the browser can show a file:// image anywhere
@@ -830,10 +839,15 @@ class RulesPane(Static):
                 self.query_one("#io-src-input", Input).value = self._matched_files[0]
         elif event.button.id == "show-psd":
             if self._matched_files and not self._psd_in_flight:
-                # single-flight: resolve the (reused) temp path first (may raise), THEN
-                # lock so a preview update can't re-enable the button mid-compute and a
-                # double-click can't run two workers writing the same psd.png (#101)
-                out_path = self._psd_png_path()
+                # single-flight: resolve the (reused) temp path first — guard it, since
+                # mkdtemp can raise here in the UI handler (not the worker); leave the
+                # lock false on failure. THEN lock so a preview update can't re-enable
+                # the button mid-compute and a double-click can't run two writers (#101).
+                try:
+                    out_path = self._psd_png_path()
+                except Exception as exc:
+                    self._set_preview(f"PSD error: {exc}", "error")
+                    return
                 self._psd_in_flight = True
                 self._update_psd_btn()
                 self._set_preview("Computing PSD — window will open separately…", "muted")

--- a/sovabids/tui.py
+++ b/sovabids/tui.py
@@ -620,6 +620,7 @@ class RulesPane(Static):
         super().__init__()
         self._preview_timer = None
         self._ext_count_timer = None
+        self._preview_gen = 0   # bumped per scan; stale workers' results are dropped (#99)
         self._matched_files: list[str] = []
         self._psd_in_flight = False   # a PSD worker is running; keep its button locked (#101)
 
@@ -971,32 +972,38 @@ class RulesPane(Static):
         self._preview_timer = self.set_timer(0.6, self._run_preview)
 
     def _run_preview(self) -> None:
+        self._preview_gen += 1          # supersede any in-flight scan (#99)
+        gen = self._preview_gen
         source = self._get_source()
         ext = self.query_one("#ext-select", Select).value
         mode, fields = self._get_mode_and_fields()
         if not source:
             self._set_preview("Set source directory in Setup tab first.", "muted")
+            self._update_show_files_btn([])
             return
         if mode == "example":
             io_src, io_tgt = self._get_io_example()
             if not io_src or not io_tgt:
                 self._set_preview("File example mode: enter source and target paths above.", "muted")
+                self._update_show_files_btn([])
                 return
             self._set_preview("Deriving pattern from example…", "muted")
-            self._preview_worker(source, "", str(ext), mode, fields, io_src, io_tgt)
+            self._preview_worker(gen, source, "", str(ext), mode, fields, io_src, io_tgt)
             return
         pattern = self.query_one("#pattern-input", Input).value.strip()
         if not pattern:
             self._set_preview("Enter a pattern above.", "muted")
+            self._update_show_files_btn([])
             return
         if mode == "regex" and not fields:
             self._set_preview("Regex mode: enter fields above.", "muted")
+            self._update_show_files_btn([])
             return
         self._set_preview("Scanning…", "muted")
-        self._preview_worker(source, pattern, str(ext), mode, fields)
+        self._preview_worker(gen, source, pattern, str(ext), mode, fields)
 
     @work(thread=True, exclusive=True, group="preview")
-    def _preview_worker(self, source: str, pattern: str, ext: str, mode: str, fields: list[str], io_src: str = "", io_tgt: str = "") -> None:
+    def _preview_worker(self, gen: int, source: str, pattern: str, ext: str, mode: str, fields: list[str], io_src: str = "", io_tgt: str = "") -> None:
         from sovabids.parsers import parse_from_placeholder, parse_from_regex
         from sovabids.rules import get_files
 
@@ -1005,16 +1012,14 @@ class RulesPane(Static):
                 from sovabids.heuristics import from_io_example
                 derived_pattern = from_io_example(io_src, io_tgt).get("pattern", "")
             except Exception as exc:
-                self.app.call_from_thread(self._set_preview, f"Example error: {exc}", "error")
-                self.app.call_from_thread(self._update_show_files_btn, [])
+                self.app.call_from_thread(self._apply_preview, gen, f"Example error: {exc}", "error", [])
                 return
             # derived pattern already uses %entities.subject% notation
             scan_rules = {"non-bids": {"eeg_extension": ext, "path_analysis": {"pattern": derived_pattern}}}
             try:
                 files = get_files(source, scan_rules)
             except Exception as exc:
-                self.app.call_from_thread(self._set_preview, f"Error: {exc}", "error")
-                self.app.call_from_thread(self._update_show_files_btn, [])
+                self.app.call_from_thread(self._apply_preview, gen, f"Error: {exc}", "error", [])
                 return
             matched = []
             for f in files:
@@ -1023,23 +1028,22 @@ class RulesPane(Static):
                         matched.append(f)
                 except Exception:
                     pass
-            count = len(matched)
-            if count == 0:
-                msg = f"0 files matched with derived pattern: {derived_pattern}"
-                self.app.call_from_thread(self._set_preview, msg, "error")
+            if not matched:
+                msg, css = f"0 files matched with derived pattern: {derived_pattern}", "error"
             else:
                 example = os.path.relpath(matched[0], source)
-                msg = f"{count} file(s) matched.  Derived pattern: [cyan]{derived_pattern}[/cyan]  Example: …/{example}"
-                self.app.call_from_thread(self._set_preview, msg, "")
-            self.app.call_from_thread(self._update_show_files_btn, matched)
+                msg, css = (
+                    f"{len(matched)} file(s) matched.  Derived pattern: [cyan]{derived_pattern}[/cyan]  Example: …/{example}",
+                    "",
+                )
+            self.app.call_from_thread(self._apply_preview, gen, msg, css, matched)
             return
 
         rules = {"non-bids": {"eeg_extension": ext, "path_analysis": {"pattern": pattern}}}
         try:
             files = get_files(source, rules)
         except Exception as exc:
-            self.app.call_from_thread(self._set_preview, f"Error: {exc}", "error")
-            self.app.call_from_thread(self._update_show_files_btn, [])
+            self.app.call_from_thread(self._apply_preview, gen, f"Error: {exc}", "error", [])
             return
 
         matched = []
@@ -1054,15 +1058,20 @@ class RulesPane(Static):
             except Exception:
                 pass
 
-        count = len(matched)
-        if count == 0:
-            msg = "0 files matched — check your pattern and extension."
-            self.app.call_from_thread(self._set_preview, msg, "error")
+        if not matched:
+            msg, css = "0 files matched — check your pattern and extension.", "error"
         else:
             example = os.path.relpath(matched[0], source)
-            msg = f"{count} file(s) matched.  Example: …/{example}"
-            self.app.call_from_thread(self._set_preview, msg, "")
-        self.app.call_from_thread(self._update_show_files_btn, matched)
+            msg, css = f"{len(matched)} file(s) matched.  Example: …/{example}", ""
+        self.app.call_from_thread(self._apply_preview, gen, msg, css, matched)
+
+    def _apply_preview(self, gen: int, msg: str, css: str, matched: list) -> None:
+        # Drop results from a scan that a newer one has already superseded, so a
+        # slow stale worker can't overwrite the current count/file list (#99).
+        if gen != self._preview_gen:
+            return
+        self._set_preview(msg, css)
+        self._update_show_files_btn(matched)
 
     def _update_show_files_btn(self, files: list[str]) -> None:
         self._matched_files = files

--- a/sovabids/tui.py
+++ b/sovabids/tui.py
@@ -481,19 +481,30 @@ def _flatten_dict(d: dict, prefix: str = "") -> dict:
     return out
 
 
+def _plf_problem(value: str) -> str:
+    """Return why ``value`` is not a usable power-line frequency, or "" if fine.
+    Blank is fine (optional); otherwise it must parse and be a positive, finite
+    number (rejects nan/inf/negative, which float() would otherwise accept)."""
+    import math
+
+    if not value.strip():
+        return ""
+    try:
+        num = float(value)
+    except ValueError:
+        return f"Power line frequency must be a number in Hz, got: {value}"
+    if not math.isfinite(num) or num <= 0:
+        return f"Power line frequency must be a positive number in Hz, got: {value}"
+    return ""
+
+
 class _OptionalNumber(Validator):
-    """Blank is allowed (the field is optional); a non-blank value must parse as a
-    number. Used so an unparseable power-line frequency is flagged instead of
-    silently dropped."""
+    """Blank is allowed (the field is optional); a non-blank value must be a positive,
+    finite number. Flags an unusable power-line frequency instead of dropping it."""
 
     def validate(self, value: str) -> ValidationResult:
-        if not value.strip():
-            return self.success()
-        try:
-            float(value)
-        except ValueError:
-            return self.failure("Enter a number in Hz, e.g. 50")
-        return self.success()
+        problem = _plf_problem(value)
+        return self.failure(problem) if problem else self.success()
 
 
 # ── Rules tab ─────────────────────────────────────────────────────────────────
@@ -709,15 +720,10 @@ class RulesPane(Static):
         return self.query_one("#rules-file-input", Input).value.strip()
 
     def plf_error(self) -> str:
-        """Return an error message if the power-line frequency is set but not a
-        number, else "". Lets an action block instead of silently dropping it (#102)."""
-        val = self.query_one("#plf-input", Input).value.strip()
-        if val:
-            try:
-                float(val)
-            except ValueError:
-                return f"Power line frequency must be a number in Hz, got: {val}"
-        return ""
+        """Return an error message if the power-line frequency is set but not a usable
+        (positive, finite) number, else "". Lets an action block instead of silently
+        dropping it (#102)."""
+        return _plf_problem(self.query_one("#plf-input", Input).value.strip())
 
     def on_select_changed(self, event: Select.Changed) -> None:
         if event.select.id == "ext-select":

--- a/sovabids/tui.py
+++ b/sovabids/tui.py
@@ -498,12 +498,15 @@ def _plf_problem(value: str) -> str:
     return ""
 
 
-def _open_path_in_viewer(path: str) -> None:
-    """Open a file with the OS default handler, cross-platform (was hard-coded to
-    Linux ``xdg-open``). Waits for the opener and checks its exit code — e.g.
-    ``xdg-open`` with no usable handler exits non-zero — then falls back to the
-    browser with a *valid* ``file://`` URI (``as_uri`` handles Windows drives and
-    spaces, which a bare f-string does not)."""
+def _open_path_in_viewer(path: str) -> bool:
+    """Open a file with the OS default handler, cross-platform. Returns True if a
+    viewer/browser was launched.
+
+    Only waits *briefly* for the opener to detect an immediate failure (e.g.
+    ``xdg-open`` with no handler exits non-zero right away); a still-running opener
+    is treated as a successful hand-off and left alone — never killed — because some
+    openers stay attached to the viewer for its whole lifetime. Falls back to the
+    browser with a *valid* ``file://`` URI (``as_uri`` handles Windows drives/spaces)."""
     import subprocess
     import sys
     import webbrowser
@@ -512,17 +515,21 @@ def _open_path_in_viewer(path: str) -> None:
     try:
         if os.name == "nt":
             os.startfile(path)  # type: ignore[attr-defined]  # Windows-only; raises on failure
-            return
+            return True
         opener = "open" if sys.platform == "darwin" else "xdg-open"
-        if subprocess.run([opener, path], timeout=20).returncode == 0:
-            return
+        proc = subprocess.Popen([opener, path])
+        try:
+            if proc.wait(timeout=2) == 0:
+                return True                    # exited cleanly -> handed off
+        except subprocess.TimeoutExpired:
+            return True                        # still running -> attached to the viewer; leave it
     except Exception:
         pass
-    # opener missing, failed, or hung -> the browser can display a file:// image anywhere
+    # opener missing or exited non-zero -> the browser can show a file:// image anywhere
     try:
-        webbrowser.open(Path(path).resolve().as_uri())
+        return bool(webbrowser.open(Path(path).resolve().as_uri()))
     except Exception:
-        pass
+        return False
 
 
 class _OptionalNumber(Validator):
@@ -607,6 +614,7 @@ class RulesPane(Static):
         self._preview_timer = None
         self._ext_count_timer = None
         self._matched_files: list[str] = []
+        self._psd_in_flight = False   # a PSD worker is running; keep its button locked (#101)
 
     def compose(self) -> ComposeResult:
         # Either load an existing rules file, OR build the rules below. Loading a
@@ -821,13 +829,15 @@ class RulesPane(Static):
             if self._matched_files:
                 self.query_one("#io-src-input", Input).value = self._matched_files[0]
         elif event.button.id == "show-psd":
-            if self._matched_files and not event.button.disabled:
-                # single-flight: disable the button until the worker finishes so a
+            if self._matched_files and not self._psd_in_flight:
+                # single-flight: resolve the (reused) temp path first (may raise), THEN
+                # lock so a preview update can't re-enable the button mid-compute and a
                 # double-click can't run two workers writing the same psd.png (#101)
-                event.button.disabled = True
+                out_path = self._psd_png_path()
+                self._psd_in_flight = True
+                self._update_psd_btn()
                 self._set_preview("Computing PSD — window will open separately…", "muted")
-                # resolve the (reused) temp path on the UI thread, hand it to the worker
-                self._psd_worker(self._matched_files[0], self._psd_png_path())
+                self._psd_worker(self._matched_files[0], out_path)
         elif event.button.id == "show-channels":
             if self._matched_files:
                 self.app.push_screen(ChannelNamesScreen(self._matched_files[0]))
@@ -918,20 +928,30 @@ class RulesPane(Static):
                 fig = raw.plot_psd(fmax=fmax, show=False)
             fig.savefig(out_path, dpi=100, bbox_inches="tight")
             plt.close(fig)
-            _open_path_in_viewer(out_path)
-            self.app.call_from_thread(
-                self._set_preview,
-                f"PSD saved — opening image viewer ({os.path.basename(filepath)})",
-                "",
-            )
+            opened = _open_path_in_viewer(out_path)
+            base = os.path.basename(filepath)
+            if opened:
+                self.app.call_from_thread(
+                    self._set_preview, f"PSD saved — opening image viewer ({base})", ""
+                )
+            else:
+                self.app.call_from_thread(
+                    self._set_preview,
+                    f"PSD saved to {out_path}, but no viewer could be opened",
+                    "error",
+                )
         except Exception as exc:
             self.app.call_from_thread(self._set_preview, f"PSD error: {exc}", "error")
         finally:
-            self.app.call_from_thread(self._reenable_psd_btn)
+            self.app.call_from_thread(self._psd_done)
 
-    def _reenable_psd_btn(self) -> None:
-        # re-enable only while there are still matched files to inspect
-        self.query_one("#show-psd", Button).disabled = not bool(self._matched_files)
+    def _psd_done(self) -> None:
+        self._psd_in_flight = False
+        self._update_psd_btn()
+
+    def _update_psd_btn(self) -> None:
+        # locked while a worker runs; otherwise enabled iff there are files to inspect
+        self.query_one("#show-psd", Button).disabled = self._psd_in_flight or not bool(self._matched_files)
 
     def _schedule_preview(self) -> None:
         if self._preview_timer is not None:
@@ -1036,7 +1056,7 @@ class RulesPane(Static):
         btn = self.query_one("#show-files", Button)
         btn.label = f"Show all ({len(files)})"
         btn.disabled = not has
-        self.query_one("#show-psd", Button).disabled = not has
+        self._update_psd_btn()   # keep PSD locked if a worker is mid-flight (#101)
         self.query_one("#show-channels", Button).disabled = not has
         self.query_one("#io-pick-src", Button).disabled = not has
 

--- a/sovabids/tui.py
+++ b/sovabids/tui.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-import threading
 import time
 from copy import deepcopy
 from typing import ClassVar
@@ -614,7 +613,6 @@ class RulesPane(Static):
     RulesPane .inspect-row Button { margin-right: 1; }
     """
 
-    _preview_lock: ClassVar = threading.Lock()
     _SAMPLE_SHOW: ClassVar[int] = 2       # how many example paths to display
     _SAMPLE_COLLECT_CAP: ClassVar[int] = 200  # bound work on huge trees
 
@@ -997,7 +995,7 @@ class RulesPane(Static):
         self._set_preview("Scanning…", "muted")
         self._preview_worker(source, pattern, str(ext), mode, fields)
 
-    @work(thread=True)
+    @work(thread=True, exclusive=True, group="preview")
     def _preview_worker(self, source: str, pattern: str, ext: str, mode: str, fields: list[str], io_src: str = "", io_tgt: str = "") -> None:
         from sovabids.parsers import parse_from_placeholder, parse_from_regex
         from sovabids.rules import get_files
@@ -1016,6 +1014,7 @@ class RulesPane(Static):
                 files = get_files(source, scan_rules)
             except Exception as exc:
                 self.app.call_from_thread(self._set_preview, f"Error: {exc}", "error")
+                self.app.call_from_thread(self._update_show_files_btn, [])
                 return
             matched = []
             for f in files:
@@ -1040,6 +1039,7 @@ class RulesPane(Static):
             files = get_files(source, rules)
         except Exception as exc:
             self.app.call_from_thread(self._set_preview, f"Error: {exc}", "error")
+            self.app.call_from_thread(self._update_show_files_btn, [])
             return
 
         matched = []

--- a/sovabids/tui.py
+++ b/sovabids/tui.py
@@ -500,21 +500,29 @@ def _plf_problem(value: str) -> str:
 
 def _open_path_in_viewer(path: str) -> None:
     """Open a file with the OS default handler, cross-platform (was hard-coded to
-    Linux ``xdg-open``). Falls back to the browser, which can display a file:// image
-    anywhere."""
+    Linux ``xdg-open``). Waits for the opener and checks its exit code — e.g.
+    ``xdg-open`` with no usable handler exits non-zero — then falls back to the
+    browser with a *valid* ``file://`` URI (``as_uri`` handles Windows drives and
+    spaces, which a bare f-string does not)."""
     import subprocess
     import sys
     import webbrowser
+    from pathlib import Path
 
     try:
-        if sys.platform == "darwin":
-            subprocess.Popen(["open", path])
-        elif os.name == "nt":
-            os.startfile(path)  # type: ignore[attr-defined]  # Windows-only
-        else:
-            subprocess.Popen(["xdg-open", path])
+        if os.name == "nt":
+            os.startfile(path)  # type: ignore[attr-defined]  # Windows-only; raises on failure
+            return
+        opener = "open" if sys.platform == "darwin" else "xdg-open"
+        if subprocess.run([opener, path], timeout=20).returncode == 0:
+            return
     except Exception:
-        webbrowser.open(f"file://{os.path.abspath(path)}")
+        pass
+    # opener missing, failed, or hung -> the browser can display a file:// image anywhere
+    try:
+        webbrowser.open(Path(path).resolve().as_uri())
+    except Exception:
+        pass
 
 
 class _OptionalNumber(Validator):
@@ -813,7 +821,10 @@ class RulesPane(Static):
             if self._matched_files:
                 self.query_one("#io-src-input", Input).value = self._matched_files[0]
         elif event.button.id == "show-psd":
-            if self._matched_files:
+            if self._matched_files and not event.button.disabled:
+                # single-flight: disable the button until the worker finishes so a
+                # double-click can't run two workers writing the same psd.png (#101)
+                event.button.disabled = True
                 self._set_preview("Computing PSD — window will open separately…", "muted")
                 # resolve the (reused) temp path on the UI thread, hand it to the worker
                 self._psd_worker(self._matched_files[0], self._psd_png_path())
@@ -915,6 +926,12 @@ class RulesPane(Static):
             )
         except Exception as exc:
             self.app.call_from_thread(self._set_preview, f"PSD error: {exc}", "error")
+        finally:
+            self.app.call_from_thread(self._reenable_psd_btn)
+
+    def _reenable_psd_btn(self) -> None:
+        # re-enable only while there are still matched files to inspect
+        self.query_one("#show-psd", Button).disabled = not bool(self._matched_files)
 
     def _schedule_preview(self) -> None:
         if self._preview_timer is not None:

--- a/sovabids/tui.py
+++ b/sovabids/tui.py
@@ -498,6 +498,25 @@ def _plf_problem(value: str) -> str:
     return ""
 
 
+def _open_path_in_viewer(path: str) -> None:
+    """Open a file with the OS default handler, cross-platform (was hard-coded to
+    Linux ``xdg-open``). Falls back to the browser, which can display a file:// image
+    anywhere."""
+    import subprocess
+    import sys
+    import webbrowser
+
+    try:
+        if sys.platform == "darwin":
+            subprocess.Popen(["open", path])
+        elif os.name == "nt":
+            os.startfile(path)  # type: ignore[attr-defined]  # Windows-only
+        else:
+            subprocess.Popen(["xdg-open", path])
+    except Exception:
+        webbrowser.open(f"file://{os.path.abspath(path)}")
+
+
 class _OptionalNumber(Validator):
     """Blank is allowed (the field is optional); a non-blank value must be a positive,
     finite number. Flags an unusable power-line frequency instead of dropping it."""
@@ -796,7 +815,8 @@ class RulesPane(Static):
         elif event.button.id == "show-psd":
             if self._matched_files:
                 self._set_preview("Computing PSD — window will open separately…", "muted")
-                self._psd_worker(self._matched_files[0])
+                # resolve the (reused) temp path on the UI thread, hand it to the worker
+                self._psd_worker(self._matched_files[0], self._psd_png_path())
         elif event.button.id == "show-channels":
             if self._matched_files:
                 self.app.push_screen(ChannelNamesScreen(self._matched_files[0]))
@@ -853,11 +873,27 @@ class RulesPane(Static):
         )
         self.app.call_from_thread(self._update_samples, samples[: self._SAMPLE_SHOW], source)
 
-    @work(thread=True)
-    def _psd_worker(self, filepath: str) -> None:
-        import subprocess
+    def _psd_png_path(self) -> str:
+        """A single, reused temp file for the PSD preview so repeated clicks
+        overwrite one PNG instead of leaking a new one each time. The directory is
+        removed in ``on_unmount``."""
         import tempfile
 
+        d = getattr(self, "_psd_dir", None)
+        if not d or not os.path.isdir(d):
+            d = tempfile.mkdtemp(prefix="sovabids_psd_")
+            self._psd_dir = d
+        return os.path.join(d, "psd.png")
+
+    def on_unmount(self) -> None:
+        d = getattr(self, "_psd_dir", None)
+        if d:
+            import shutil
+
+            shutil.rmtree(d, ignore_errors=True)
+
+    @work(thread=True)
+    def _psd_worker(self, filepath: str, out_path: str) -> None:
         try:
             import matplotlib
             import matplotlib.pyplot as plt
@@ -869,11 +905,9 @@ class RulesPane(Static):
                 fig = raw.compute_psd(fmax=fmax).plot(show=False)
             except AttributeError:
                 fig = raw.plot_psd(fmax=fmax, show=False)
-            with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
-                tmp = f.name
-            fig.savefig(tmp, dpi=100, bbox_inches="tight")
+            fig.savefig(out_path, dpi=100, bbox_inches="tight")
             plt.close(fig)
-            subprocess.Popen(["xdg-open", tmp])
+            _open_path_in_viewer(out_path)
             self.app.call_from_thread(
                 self._set_preview,
                 f"PSD saved — opening image viewer ({os.path.basename(filepath)})",

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -570,6 +570,9 @@ async def test_tui_plf_field_validates_number(tmp_path):
         assert plf.validate("50").is_valid
         assert plf.validate("50.5").is_valid
         assert not plf.validate("50hz").is_valid   # flagged, not silently dropped
+        assert not plf.validate("nan").is_valid    # non-finite rejected
+        assert not plf.validate("inf").is_valid
+        assert not plf.validate("-5").is_valid     # must be positive
         from sovabids.tui import MappingsPane
         assert not hasattr(MappingsPane, "_mappings")
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -609,7 +609,7 @@ async def test_tui_preview_error_clears_stale_buttons(monkeypatch, tmp_path):
         def boom(*a, **k):
             raise RuntimeError("bad source")
         monkeypatch.setattr(sr, "get_files", boom)
-        rp._preview_worker(str(tmp_path), "%subject%.vhdr", ".vhdr", "placeholder", [])
+        rp._preview_worker(rp._preview_gen, str(tmp_path), "%subject%.vhdr", ".vhdr", "placeholder", [])
         for _ in range(30):
             await anyio.sleep(0.1)
             await pilot.pause()
@@ -618,6 +618,45 @@ async def test_tui_preview_error_clears_stale_buttons(monkeypatch, tmp_path):
         assert rp._matched_files == []
         assert app.query_one("#show-files", Button).disabled
         assert app.query_one("#show-psd", Button).disabled
+
+
+@pytest.mark.anyio
+async def test_tui_preview_stale_result_dropped(tmp_path):
+    """A scan whose generation was superseded by a newer one must not overwrite the
+    current file list (the exclusive-worker race codex flagged) (#99)."""
+    app = SovabidsApp()
+    async with app.run_test(size=(120, 80)) as pilot:
+        app.query_one("TabbedContent").active = "tab-rules"
+        await pilot.pause()
+        rp = app.query_one("RulesPane")
+        rp._preview_gen = 5
+        # an OLD worker (gen 4) finishing after a newer scan (gen 5) is ignored
+        rp._apply_preview(4, "STALE 3 file(s) matched", "", ["/old/a.vhdr"])
+        assert rp._matched_files == []
+        # a current-generation result applies
+        rp._apply_preview(5, "2 file(s) matched", "", ["/new/a.vhdr", "/new/b.vhdr"])
+        assert rp._matched_files == ["/new/a.vhdr", "/new/b.vhdr"]
+
+
+@pytest.mark.anyio
+async def test_tui_preview_early_return_clears_buttons(tmp_path):
+    """Clearing the pattern after a good scan clears the stale matched files/buttons via
+    _run_preview's early return, not just the worker error path (#99)."""
+    app = SovabidsApp()
+    async with app.run_test(size=(120, 80)) as pilot:
+        app.query_one("TabbedContent").active = "tab-rules"
+        await pilot.pause()
+        rp = app.query_one("RulesPane")
+        rp._update_show_files_btn(["/a/x.vhdr"])          # pretend a prior good scan
+        assert not app.query_one("#show-files", Button).disabled
+        # source set, pattern empty -> _run_preview early-returns and must clear
+        app.query_one("#source-input", Input).value = "/some/src"
+        app.query_one("#pattern-input", Input).value = ""
+        await pilot.pause()
+        rp._run_preview()
+        await pilot.pause()
+        assert rp._matched_files == []
+        assert app.query_one("#show-files", Button).disabled
 
 
 @pytest.mark.anyio

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -598,10 +598,11 @@ async def test_tui_preview_error_clears_stale_buttons(monkeypatch, tmp_path):
         app.query_one("TabbedContent").active = "tab-rules"
         await pilot.pause()
         rp = app.query_one("RulesPane")
+        await anyio.sleep(0.7)   # let any mount-time scheduled preview settle (it clears matches)
+        await pilot.pause()
 
         # simulate a prior successful scan -> action buttons enabled
         rp._update_show_files_btn(["/a/x.vhdr", "/a/y.vhdr"])
-        await pilot.pause()
         assert rp._matched_files
         assert not app.query_one("#show-files", Button).disabled
 
@@ -636,6 +637,27 @@ async def test_tui_preview_stale_result_dropped(tmp_path):
         # a current-generation result applies
         rp._apply_preview(5, "2 file(s) matched", "", ["/new/a.vhdr", "/new/b.vhdr"])
         assert rp._matched_files == ["/new/a.vhdr", "/new/b.vhdr"]
+
+
+@pytest.mark.anyio
+async def test_tui_preview_edit_supersedes_in_flight(tmp_path):
+    """Editing (which schedules a preview) immediately bumps the generation and clears
+    stale matches, so a worker in flight from before the edit is dropped (#99)."""
+    app = SovabidsApp()
+    async with app.run_test(size=(120, 80)) as pilot:
+        app.query_one("TabbedContent").active = "tab-rules"
+        await pilot.pause()
+        rp = app.query_one("RulesPane")
+        rp._update_show_files_btn(["/a/x.vhdr"])
+        gen_before = rp._preview_gen        # what an in-flight worker would have captured
+
+        rp._schedule_preview()              # user edits -> schedule
+        assert rp._preview_gen > gen_before # token bumped on the edit itself, not at debounce
+        assert rp._matched_files == []      # stale matches cleared immediately
+
+        # the pre-edit worker now lands -> its result is dropped
+        rp._apply_preview(gen_before, "STALE 5 matched", "", ["/a/x.vhdr"])
+        assert rp._matched_files == []
 
 
 @pytest.mark.anyio

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -558,6 +558,23 @@ async def test_tui_rules_shows_sample_paths(dummy_source):
 
 
 @pytest.mark.anyio
+async def test_tui_plf_field_validates_number(tmp_path):
+    """A non-numeric power-line frequency is flagged (not silently dropped); blank and
+    numbers are accepted. Also guards that the dead `_mappings` reactive stays removed."""
+    app = SovabidsApp()
+    async with app.run_test(size=(120, 80)) as pilot:
+        app.query_one("TabbedContent").active = "tab-rules"
+        await pilot.pause()
+        plf = app.query_one("#plf-input", Input)
+        assert plf.validate("").is_valid          # blank ok (optional field)
+        assert plf.validate("50").is_valid
+        assert plf.validate("50.5").is_valid
+        assert not plf.validate("50hz").is_valid   # flagged, not silently dropped
+        from sovabids.tui import MappingsPane
+        assert not hasattr(MappingsPane, "_mappings")
+
+
+@pytest.mark.anyio
 async def test_tui_files_modal(dummy_source):
     app = SovabidsApp()
     # tall viewport so the Rules-tab content (ext + sample paths + pattern +

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -573,6 +573,17 @@ async def test_tui_plf_field_validates_number(tmp_path):
         from sovabids.tui import MappingsPane
         assert not hasattr(MappingsPane, "_mappings")
 
+        # and an invalid PLF must BLOCK Generate (not be silently dropped by get_rules)
+        app.query_one("#source-input", Input).value = "/some/source"
+        app.query_one("#bids-input", Input).value = "/some/bids"
+        plf.value = "50hz"
+        await pilot.pause()
+        app.query_one(MappingsPane)._generate()
+        await pilot.pause()
+        status = str(app.query_one("#mappings-status", Static).render()).lower()
+        assert "power line frequency" in status
+        assert getattr(app, "_mapping_data", None) is None   # no generation started
+
 
 @pytest.mark.anyio
 async def test_tui_files_modal(dummy_source):

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -589,6 +589,44 @@ async def test_tui_plf_field_validates_number(tmp_path):
 
 
 @pytest.mark.anyio
+async def test_tui_psd_temp_reuse_and_cleanup(tmp_path):
+    """The PSD preview reuses one temp PNG (no per-click leak) and removes it on exit."""
+    from sovabids.tui import RulesPane
+    app = SovabidsApp()
+    async with app.run_test(size=(120, 80)) as pilot:
+        rp = app.query_one(RulesPane)
+        p1 = rp._psd_png_path()
+        p2 = rp._psd_png_path()
+        assert p1 == p2                                   # reused, not a fresh temp per call
+        assert os.path.basename(p1) == "psd.png"
+        assert os.path.isdir(os.path.dirname(p1))
+        d = rp._psd_dir
+    assert not os.path.exists(d)                          # cleaned up on unmount
+
+
+def test_tui_open_in_viewer_is_cross_platform(monkeypatch):
+    """_open_path_in_viewer dispatches to the OS opener and falls back to the browser."""
+    import subprocess
+    import webbrowser
+    import sovabids.tui as tui
+    calls = {}
+    monkeypatch.setattr(
+        subprocess, "Popen",
+        lambda args, *a, **k: calls.setdefault("popen", []).append(list(args)),
+    )
+    monkeypatch.setattr(webbrowser, "open", lambda url: calls.setdefault("web", []).append(url))
+    tui._open_path_in_viewer("/tmp/x.png")
+    assert calls.get("popen"), "should invoke an OS opener"        # (xdg-open on Linux CI)
+
+    # if the opener is unavailable, fall back to the browser instead of raising
+    def boom(*a, **k):
+        raise FileNotFoundError("no opener")
+    monkeypatch.setattr(subprocess, "Popen", boom)
+    tui._open_path_in_viewer("/tmp/y.png")
+    assert calls.get("web") == ["file:///tmp/y.png"]
+
+
+@pytest.mark.anyio
 async def test_tui_files_modal(dummy_source):
     app = SovabidsApp()
     # tall viewport so the Rules-tab content (ext + sample paths + pattern +

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -605,61 +605,81 @@ async def test_tui_psd_temp_reuse_and_cleanup(tmp_path):
 
 
 def test_tui_open_in_viewer_is_cross_platform(monkeypatch):
-    """_open_path_in_viewer runs the OS opener AND checks its exit code, falling back to
-    the browser (with a valid file:// URI) when the opener fails."""
+    """_open_path_in_viewer launches the OS opener without killing an attached viewer,
+    detects an immediate non-zero exit, and falls back to the browser (valid URI)."""
     import subprocess
     import webbrowser
     from pathlib import Path
     import sovabids.tui as tui
 
-    class _R:
-        def __init__(self, rc):
-            self.returncode = rc
+    class _P:
+        def __init__(self, rc, hang=False):
+            self._rc, self._hang = rc, hang
+        def wait(self, timeout=None):
+            if self._hang:
+                raise subprocess.TimeoutExpired("opener", timeout)
+            return self._rc
 
     calls = {}
-    # opener succeeds (rc 0) -> no browser fallback
+    # opener exits 0 -> success, no fallback
     monkeypatch.setattr(
-        subprocess, "run",
-        lambda args, **k: (calls.setdefault("run", []).append(list(args)), _R(0))[1],
+        subprocess, "Popen",
+        lambda args, **k: (calls.setdefault("popen", []).append(list(args)), _P(0))[1],
     )
-    monkeypatch.setattr(webbrowser, "open", lambda url: calls.setdefault("web", []).append(url))
-    tui._open_path_in_viewer("/tmp/x.png")
-    assert calls.get("run") and calls["run"][0][0] in ("xdg-open", "open")
-    assert "web" not in calls                                     # rc 0 -> no fallback
+    monkeypatch.setattr(webbrowser, "open", lambda url: calls.setdefault("web", []).append(url) or True)
+    assert tui._open_path_in_viewer("/tmp/x.png") is True
+    assert calls["popen"][0][0] in ("xdg-open", "open")
+    assert "web" not in calls
 
-    # opener returns NON-zero (e.g. xdg-open with no handler) -> browser fallback,
-    # and the URI is a valid file:// (spaces escaped), not a bare f-string
+    # opener still running past the short wait -> treated as a hand-off, NOT killed, no fallback
     calls.clear()
-    monkeypatch.setattr(subprocess, "run", lambda args, **k: _R(3))
-    monkeypatch.setattr(webbrowser, "open", lambda url: calls.setdefault("web", []).append(url))
-    tui._open_path_in_viewer("/tmp/name with space.png")
+    monkeypatch.setattr(subprocess, "Popen", lambda args, **k: _P(0, hang=True))
+    assert tui._open_path_in_viewer("/tmp/x.png") is True
+    assert "web" not in calls
+
+    # opener exits non-zero -> browser fallback with a valid file:// URI (spaces escaped)
+    calls.clear()
+    monkeypatch.setattr(subprocess, "Popen", lambda args, **k: _P(3))
+    monkeypatch.setattr(webbrowser, "open", lambda url: calls.setdefault("web", []).append(url) or True)
+    assert tui._open_path_in_viewer("/tmp/name with space.png") is True
     assert calls["web"] == [Path("/tmp/name with space.png").resolve().as_uri()]
+
+    # both fail -> returns False so the caller can report it
+    monkeypatch.setattr(subprocess, "Popen", lambda args, **k: _P(3))
+    monkeypatch.setattr(webbrowser, "open", lambda url: False)
+    assert tui._open_path_in_viewer("/tmp/x.png") is False
 
 
 @pytest.mark.anyio
 async def test_tui_psd_single_flight(monkeypatch, tmp_path):
-    """Pressing Power Spectrum disables the button until the worker finishes, so a
-    double-click can't run two workers writing the same psd.png (#101)."""
+    """Power Spectrum stays locked for the worker's whole life; a concurrent preview
+    update must not re-enable it mid-compute (which would allow a second writer) (#101)."""
     app = SovabidsApp()
     async with app.run_test(size=(120, 80)) as pilot:
         app.query_one("TabbedContent").active = "tab-rules"
         await pilot.pause()
         rp = app.query_one("RulesPane")
-        rp._matched_files = ["/a/x.vhdr"]
+        rp._update_show_files_btn(["/a/x.vhdr"])       # a prior good scan -> PSD enabled
+        btn = app.query_one("#show-psd", Button)
+        assert not btn.disabled
         started = []
         monkeypatch.setattr(rp, "_psd_worker", lambda *a, **k: started.append(a))  # stub MNE work
-        btn = app.query_one("#show-psd", Button)
-        btn.disabled = False
 
         rp.on_button_pressed(Button.Pressed(btn))
         await pilot.pause()
-        assert started                          # worker launched
-        assert btn.disabled is True             # single-flight: button locked during compute
+        assert started
+        assert rp._psd_in_flight is True
+        assert btn.disabled is True                    # locked during compute
 
-        rp._reenable_psd_btn()                  # worker's finally re-enables (files still matched)
-        assert btn.disabled is False
+        # a preview result landing mid-compute must NOT re-enable it
+        rp._update_show_files_btn(["/a/x.vhdr", "/a/y.vhdr"])
+        assert btn.disabled is True
+
+        rp._psd_done()                                 # worker's finally releases the lock
+        assert rp._psd_in_flight is False
+        assert not btn.disabled
         rp._matched_files = []
-        rp._reenable_psd_btn()
+        rp._update_psd_btn()
         assert btn.disabled is True
 
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -589,6 +589,38 @@ async def test_tui_plf_field_validates_number(tmp_path):
 
 
 @pytest.mark.anyio
+async def test_tui_preview_error_clears_stale_buttons(monkeypatch, tmp_path):
+    """A failed rescan clears the matched-file list and disables the action buttons,
+    so they can't keep operating on the previous (now-invalid) scan's files."""
+    import sovabids.rules as sr
+    app = SovabidsApp()
+    async with app.run_test(size=(120, 80)) as pilot:
+        app.query_one("TabbedContent").active = "tab-rules"
+        await pilot.pause()
+        rp = app.query_one("RulesPane")
+
+        # simulate a prior successful scan -> action buttons enabled
+        rp._update_show_files_btn(["/a/x.vhdr", "/a/y.vhdr"])
+        await pilot.pause()
+        assert rp._matched_files
+        assert not app.query_one("#show-files", Button).disabled
+
+        # a rescan whose get_files fails must clear the stale list + disable actions
+        def boom(*a, **k):
+            raise RuntimeError("bad source")
+        monkeypatch.setattr(sr, "get_files", boom)
+        rp._preview_worker(str(tmp_path), "%subject%.vhdr", ".vhdr", "placeholder", [])
+        for _ in range(30):
+            await anyio.sleep(0.1)
+            await pilot.pause()
+            if not rp._matched_files:
+                break
+        assert rp._matched_files == []
+        assert app.query_one("#show-files", Button).disabled
+        assert app.query_one("#show-psd", Button).disabled
+
+
+@pytest.mark.anyio
 async def test_tui_psd_temp_reuse_and_cleanup(tmp_path):
     """The PSD preview reuses one temp PNG (no per-click leak) and removes it on exit."""
     from sovabids.tui import RulesPane

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -605,25 +605,62 @@ async def test_tui_psd_temp_reuse_and_cleanup(tmp_path):
 
 
 def test_tui_open_in_viewer_is_cross_platform(monkeypatch):
-    """_open_path_in_viewer dispatches to the OS opener and falls back to the browser."""
+    """_open_path_in_viewer runs the OS opener AND checks its exit code, falling back to
+    the browser (with a valid file:// URI) when the opener fails."""
     import subprocess
     import webbrowser
+    from pathlib import Path
     import sovabids.tui as tui
+
+    class _R:
+        def __init__(self, rc):
+            self.returncode = rc
+
     calls = {}
+    # opener succeeds (rc 0) -> no browser fallback
     monkeypatch.setattr(
-        subprocess, "Popen",
-        lambda args, *a, **k: calls.setdefault("popen", []).append(list(args)),
+        subprocess, "run",
+        lambda args, **k: (calls.setdefault("run", []).append(list(args)), _R(0))[1],
     )
     monkeypatch.setattr(webbrowser, "open", lambda url: calls.setdefault("web", []).append(url))
     tui._open_path_in_viewer("/tmp/x.png")
-    assert calls.get("popen"), "should invoke an OS opener"        # (xdg-open on Linux CI)
+    assert calls.get("run") and calls["run"][0][0] in ("xdg-open", "open")
+    assert "web" not in calls                                     # rc 0 -> no fallback
 
-    # if the opener is unavailable, fall back to the browser instead of raising
-    def boom(*a, **k):
-        raise FileNotFoundError("no opener")
-    monkeypatch.setattr(subprocess, "Popen", boom)
-    tui._open_path_in_viewer("/tmp/y.png")
-    assert calls.get("web") == ["file:///tmp/y.png"]
+    # opener returns NON-zero (e.g. xdg-open with no handler) -> browser fallback,
+    # and the URI is a valid file:// (spaces escaped), not a bare f-string
+    calls.clear()
+    monkeypatch.setattr(subprocess, "run", lambda args, **k: _R(3))
+    monkeypatch.setattr(webbrowser, "open", lambda url: calls.setdefault("web", []).append(url))
+    tui._open_path_in_viewer("/tmp/name with space.png")
+    assert calls["web"] == [Path("/tmp/name with space.png").resolve().as_uri()]
+
+
+@pytest.mark.anyio
+async def test_tui_psd_single_flight(monkeypatch, tmp_path):
+    """Pressing Power Spectrum disables the button until the worker finishes, so a
+    double-click can't run two workers writing the same psd.png (#101)."""
+    app = SovabidsApp()
+    async with app.run_test(size=(120, 80)) as pilot:
+        app.query_one("TabbedContent").active = "tab-rules"
+        await pilot.pause()
+        rp = app.query_one("RulesPane")
+        rp._matched_files = ["/a/x.vhdr"]
+        started = []
+        monkeypatch.setattr(rp, "_psd_worker", lambda *a, **k: started.append(a))  # stub MNE work
+        btn = app.query_one("#show-psd", Button)
+        btn.disabled = False
+
+        rp.on_button_pressed(Button.Pressed(btn))
+        await pilot.pause()
+        assert started                          # worker launched
+        assert btn.disabled is True             # single-flight: button locked during compute
+
+        rp._reenable_psd_btn()                  # worker's finally re-enables (files still matched)
+        assert btn.disabled is False
+        rp._matched_files = []
+        rp._reenable_psd_btn()
+        assert btn.disabled is True
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Fixes #99. Stacked on #104 (base `fix/101-psd-portability`).

Two related defects in the Rules-tab live preview:

- **Race / last-completion-wins.** `_preview_worker` was a non-exclusive thread worker, so a slow scan for an older pattern could finish after a newer one and overwrite the current count/file list. Now `@work(thread=True, exclusive=True, group="preview")` — a new scan cancels the in-flight one (same pattern already used for the ext-count worker).
- **Stale action buttons on error.** On a `get_files` failure the worker set an error message and returned **without** resetting `_matched_files`/the buttons, leaving *Show all*, *Power Spectrum*, *Channel Names*, and *Pick first match* enabled and pointing at the previous scan's files. Both error paths now call `_update_show_files_btn([])`.
- Removed the declared-but-never-acquired `_preview_lock` (and the now-unused `threading` import) — making the worker exclusive removes the concurrent-write concern the lock was meant to guard.

Test: a rescan whose `get_files` raises now clears the file list and disables the actions. Full TUI suite (minus the slow e2e) green.